### PR TITLE
Update external connectors in version 12 network

### DIFF
--- a/project_cards/year_2015_new_roadway_I-505_centroid_connector NB.yaml
+++ b/project_cards/year_2015_new_roadway_I-505_centroid_connector NB.yaml
@@ -16,3 +16,8 @@ changes:
     roadway: taz
     walk_access: 0
     assignable: 1
+- category: Roadway Deletion
+  links:
+    model_link_id:
+    - 5117530
+    - 5118443

--- a/project_cards/year_2015_new_roadway_antioch_bridge_CA-160_centroid_connector NB.yaml
+++ b/project_cards/year_2015_new_roadway_antioch_bridge_CA-160_centroid_connector NB.yaml
@@ -17,3 +17,8 @@ changes:
     roadway: taz
     walk_access: 0
     assignable: 1
+- category: Roadway Deletion
+  links:
+    model_link_id:
+    - 4239334
+    - 4241510

--- a/project_cards/year_2015_new_roadway_cabrillo_highway_CA-1_centroid_connector NB.yaml
+++ b/project_cards/year_2015_new_roadway_cabrillo_highway_CA-1_centroid_connector NB.yaml
@@ -17,3 +17,8 @@ changes:
     roadway: taz
     walk_access: 0
     assignable: 1
+- category: Roadway Deletion
+  links:
+    model_link_id:
+    - 1143651
+    - 1142182

--- a/project_cards/year_2015_new_roadway_dwight_d_eisenhower_highway_I-80_centroid_connector EB.yaml
+++ b/project_cards/year_2015_new_roadway_dwight_d_eisenhower_highway_I-80_centroid_connector EB.yaml
@@ -17,3 +17,8 @@ changes:
     roadway: taz
     walk_access: 0
     assignable: 1
+- category: Roadway Deletion
+  links:
+    model_link_id:
+    - 5118662
+    - 5117749

--- a/project_cards/year_2015_new_roadway_pacheco_pass_highway_CA-152_NB_centroid_connector.yaml
+++ b/project_cards/year_2015_new_roadway_pacheco_pass_highway_CA-152_NB_centroid_connector.yaml
@@ -17,3 +17,8 @@ changes:
     roadway: taz
     walk_access: 0
     assignable: 1
+- category: Roadway Deletion
+  links:
+    model_link_id:
+    - 2518654
+    - 2522313

--- a/project_cards/year_2015_new_roadway_redwood_highway_US-101_centroid_connector NB.yaml
+++ b/project_cards/year_2015_new_roadway_redwood_highway_US-101_centroid_connector NB.yaml
@@ -17,3 +17,8 @@ changes:
     roadway: taz
     walk_access: 0
     assignable: 1
+- category: Roadway Deletion
+  links:
+    model_link_id:
+    - 7135835
+    - 7137048

--- a/project_cards/year_2015_new_roadway_santa_cruz_highway_CA-17_centroid_connector NB.yaml
+++ b/project_cards/year_2015_new_roadway_santa_cruz_highway_CA-17_centroid_connector NB.yaml
@@ -17,3 +17,8 @@ changes:
     roadway: taz
     walk_access: 0
     assignable: 1
+- category: Roadway Deletion
+  links:
+    model_link_id:
+    - 2522059
+    - 2518400

--- a/project_cards/year_2015_new_roadway_skyline_boulevard_CA-35_centroid_connector NB.yaml
+++ b/project_cards/year_2015_new_roadway_skyline_boulevard_CA-35_centroid_connector NB.yaml
@@ -17,3 +17,8 @@ changes:
     roadway: taz
     walk_access: 0
     assignable: 1
+- category: Roadway Deletion
+  links:
+    model_link_id:
+    - 2522058
+    - 2518399

--- a/project_cards/year_2015_new_roadway_south_valley_freeway_US-101_centroid_connector NB.yaml
+++ b/project_cards/year_2015_new_roadway_south_valley_freeway_US-101_centroid_connector NB.yaml
@@ -17,3 +17,8 @@ changes:
     roadway: taz
     walk_access: 0
     assignable: 1
+- category: Roadway Deletion
+  links:
+    model_link_id:
+    - 2519408
+    - 2523067

--- a/project_cards/year_2015_new_roadway_vic_fazio_highway_CA-113_centroid_connector SB.yaml
+++ b/project_cards/year_2015_new_roadway_vic_fazio_highway_CA-113_centroid_connector SB.yaml
@@ -17,3 +17,8 @@ changes:
     roadway: taz
     walk_access: 0
     assignable: 1
+- category: Roadway Deletion
+  links:
+    model_link_id:
+    - 5118661
+    - 5117748

--- a/project_cards/year_2015_new_roadway_william_elton_brown_freeway_I-580_centroid_connector NB.yaml
+++ b/project_cards/year_2015_new_roadway_william_elton_brown_freeway_I-580_centroid_connector NB.yaml
@@ -17,3 +17,8 @@ changes:
     roadway: taz
     walk_access: 0
     assignable: 1
+- category: Roadway Deletion
+  links:
+    model_link_id:
+    - 3320292
+    - 3316432


### PR DESCRIPTION
External connectors are added by project cards, to manually connect external stations to highways, instead of local roads. The old (automatically generated) external connectors should be deleted.